### PR TITLE
Reduce CPU usage in process/thread waiting

### DIFF
--- a/lios/main.py
+++ b/lios/main.py
@@ -480,8 +480,8 @@ class linux_intelligent_ocr_solution():
 		.format(destination,destination.split(".")[0],pdf_filename.split(".")[0])) , args=())
 		
 		p.start()
-		while(p.is_alive()):
-			pass
+		while p.is_alive():
+			time.sleep(0.1)
 		os.remove(destination)
 		
 		file_list = os.listdir(destination.split(".")[0])
@@ -601,8 +601,8 @@ class linux_intelligent_ocr_solution():
 			args=(parent_conn, child_conn))
 		
 			p.start()
-			while(p.is_alive()):
-				pass
+			while p.is_alive():
+				time.sleep(0.1)
 		
 		
 			driver = self.available_scanner_driver_list[self.preferences.scan_driver]
@@ -655,8 +655,8 @@ class linux_intelligent_ocr_solution():
 		destination = self.get_feesible_filename_from_filename(destination)
 		t = threading.Thread(target=self.scan,args=(destination,))
 		t.start()
-		while(t.is_alive()):
-			pass
+		while t.is_alive():
+			time.sleep(0.1)
 		self.preferences.update_page_number()
 		#self.make_scanner_widgets_active(lock=True)
 		#self.make_preferences_widgets_active(lock=True)
@@ -680,8 +680,8 @@ class linux_intelligent_ocr_solution():
 			destination = self.get_feesible_filename_from_filename(destination)
 			t = threading.Thread(target=self.scan,args=(destination,))
 			t.start()
-			while(t.is_alive()):
-				pass
+			while t.is_alive():
+				time.sleep(0.1)
 			self.preferences.update_page_number()
 			if(self.process_breaker):
 				break
@@ -703,8 +703,8 @@ class linux_intelligent_ocr_solution():
 		self.preferences.scan_brightness,self.preferences.scan_area))
 
 		p.start()
-		while(p.is_alive()):
-			pass
+		while p.is_alive():
+			time.sleep(0.1)
 		self.notify_information(_("Scan Completed!"),0)
 			
 		if(self.process_breaker):
@@ -801,8 +801,8 @@ class linux_intelligent_ocr_solution():
 		destination = self.get_feesible_filename_from_filename(destination)
 		t = threading.Thread(target=self.scan,args=(destination,))
 		t.start()
-		while(t.is_alive()):
-			pass
+		while t.is_alive():
+			time.sleep(0.1)
 		if(self.process_breaker):
 			#self.make_scanner_widgets_active(lock=True)
 			#self.make_ocr_widgets_active(lock=True)
@@ -843,8 +843,8 @@ class linux_intelligent_ocr_solution():
 			destination = self.get_feesible_filename_from_filename(destination)
 			t = threading.Thread(target=self.scan,args=(destination,))
 			t.start()
-			while(t.is_alive()):
-				pass
+			while t.is_alive():
+				time.sleep(0.1)
 			if(self.process_breaker):
 				break
 			time.sleep(self.preferences.time_between_repeated_scanning)	
@@ -906,8 +906,8 @@ class linux_intelligent_ocr_solution():
 				self.preferences.scan_brightness,self.preferences.scan_area))
 			
 			p.start()
-			while(p.is_alive()):
-				pass
+			while p.is_alive():
+				time.sleep(0.1)
 			text,angle = self.ocr("{0}rotate.pnm".format(macros.tmp_dir),mode,00)
 			self.notify_information("Image at {} angle.".format(angle),0)
 		else:
@@ -1040,8 +1040,8 @@ class linux_intelligent_ocr_solution():
 				self.preferences.scan_resolution,pos,self.preferences.scan_area))
 				
 				p.start()
-				while(p.is_alive()):
-					pass
+				while p.is_alive():
+					time.sleep(0.1)
 				if(self.process_breaker):
 					list = sorted(list, key=lambda item: item[0],reverse=True)
 					return (list)


### PR DESCRIPTION
Add `time.sleep(0.1)` to waiting loops for processes and threads to prevent high CPU usage

fixes issue#58