### PR TITLE
Fix high CPU usage caused by busy-wait loops (Fixes #58)

### DIFF
--- a/lios/main.py
+++ b/lios/main.py
@@ -602,7 +602,7 @@ class linux_intelligent_ocr_solution():
 		
 			p.start()
 			while(p.is_alive()):
-				pass
+				time.sleep(0.1)
 		
 		
 			driver = self.available_scanner_driver_list[self.preferences.scan_driver]
@@ -656,7 +656,7 @@ class linux_intelligent_ocr_solution():
 		t = threading.Thread(target=self.scan,args=(destination,))
 		t.start()
 		while(t.is_alive()):
-			pass
+			time.sleep(0.1)
 		self.preferences.update_page_number()
 		#self.make_scanner_widgets_active(lock=True)
 		#self.make_preferences_widgets_active(lock=True)
@@ -681,7 +681,7 @@ class linux_intelligent_ocr_solution():
 			t = threading.Thread(target=self.scan,args=(destination,))
 			t.start()
 			while(t.is_alive()):
-				pass
+				time.sleep(0.1)
 			self.preferences.update_page_number()
 			if(self.process_breaker):
 				break
@@ -704,7 +704,7 @@ class linux_intelligent_ocr_solution():
 
 		p.start()
 		while(p.is_alive()):
-			pass
+			time.sleep(0.1)
 		self.notify_information(_("Scan Completed!"),0)
 			
 		if(self.process_breaker):


### PR DESCRIPTION
This PR addresses issue #58 related to high CPU usage caused by busy-wait loops in lios/main.py.

Several places in the code used patterns such as:

while x.is_alive():
    pass


These loops continuously poll the thread/process status without yielding, which results in unnecessary CPU consumption.
To avoid this, I replaced the busy-wait loops with:

time.sleep(0.1)


This keeps the original control flow intact while reducing CPU load significantly. The change is minimal, localized, and does not alter behavior beyond preventing the tight spin.

If there are specific locations where you'd prefer an alternative approach (e.g., using .join()), I’m happy to update the PR.

Fixes #58.